### PR TITLE
First version with binary_trees and a simple programs as examples.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+make mini-cheri
+make ss-cheri
+make bt-cheri-opt

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+BasedOnStyle: LLVM
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortFunctionsOnASingleLine: Empty
+AllowAllArgumentsOnNextLine: true
+BreakBeforeBraces: Allman
+BraceWrapping:
+	AfterControlStatement: Always
+
+ColumnLimit: 100
+

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,19 @@ CHERI_FLAGS=-march=rv64imafdcxcheri -mabi=l64pc128d --sysroot=$(HOME)/cheri/outp
 
 export 
 
-all: main
+all: mini bt ss
 
-main: main.cpp
+mini-opt: main.cpp
 	$(CXX) -ggdb --std=c++20 -O3 main.cpp -D NDEBUG -o main
 
-debug:
+mini:
 	$(CXX) -ggdb --std=c++20 -O0 main.cpp -o main
 
-cheri:
+mini-cheri:
 	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O0 main.cpp -o main
+
+mini-cheri-opt:
+	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O3 main.cpp -D NDEBUG -o main
 
 bt:
 	$(CXX) -ggdb --std=c++20 -O0 binary_trees.cpp -o binary_trees
@@ -31,7 +34,7 @@ ss-opt:
 	$(CXX) -ggdb --std=c++20 -O3 stack.cpp -D NDEBUG -o stack_scan
 
 ss-cheri-opt:
-	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O0 stack.cpp -D NDEBUG -o stack_scan
+	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O3 stack.cpp -D NDEBUG -o stack_scan
 
 ss-cheri:
 	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O0 stack.cpp -o stack_scan

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+CXX=$(HOME)/cheri/output/sdk/bin/clang++
+CHERI_CXX=$(HOME)/cheri/output/sdk/bin/riscv64-unknown-freebsd13-clang++
+CHERI_FLAGS=-march=rv64imafdcxcheri -mabi=l64pc128d --sysroot=$(HOME)/cheri/output/rootfs-riscv64-hybrid -mno-relax
+
+export 
+
+all: main
+
+main: main.cpp
+	$(CXX) -ggdb --std=c++20 -O3 main.cpp -D NDEBUG -o main
+
+debug:
+	$(CXX) -ggdb --std=c++20 -O0 main.cpp -o main
+
+cheri:
+	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O0 main.cpp -o main
+
+bt:
+	$(CXX) -ggdb --std=c++20 -O0 binary_trees.cpp -o binary_trees
+
+bt-opt:
+	$(CXX) -ggdb --std=c++20 -O3 binary_trees.cpp -D NDEBUG -o binary_trees
+
+bt-cheri-opt:
+	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O3 binary_trees.cpp -D NDEBUG -o binary_trees

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,15 @@ bt-opt:
 
 bt-cheri-opt:
 	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O3 binary_trees.cpp -D NDEBUG -o binary_trees
+
+ss:
+	$(CXX) -ggdb --std=c++20 -O0 stack.cpp -o stack_scan
+
+ss-opt:
+	$(CXX) -ggdb --std=c++20 -O3 stack.cpp -D NDEBUG -o stack_scan
+
+ss-cheri-opt:
+	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O0 stack.cpp -D NDEBUG -o stack_scan
+
+ss-cheri:
+	$(CHERI_CXX) -ggdb $(CHERI_FLAGS) --std=c++20 -O0 stack.cpp -o stack_scan

--- a/binary_trees.cpp
+++ b/binary_trees.cpp
@@ -3,8 +3,6 @@
 #include <iostream>
 #include <stdlib.h>
 
-#include "compressed.hpp"
-#include "cheri.h"
 #include "pointers.hpp"
 
 struct Node
@@ -42,9 +40,7 @@ Node *node_new(const int d)
   return result;
 }
 
-// using LS = PointerListStyle;
-// using LS = CompressedListStyle;
-using LS = CheriCompressedListStyle;
+using LS = PointerListStyle;
 using Iter = PointersLinkedListIterator<LS>;
 
 int main(int argc, char *argv[])

--- a/binary_trees.cpp
+++ b/binary_trees.cpp
@@ -1,0 +1,83 @@
+#include "gc.hpp"
+
+#include <iostream>
+#include <stdlib.h>
+
+struct Node
+{
+  GCObject gc;
+  Node *left;
+  Node *right;
+
+  int check() const
+  {
+    if (left)
+    {
+      return left->check() + 1 + right->check();
+    }
+    else
+    {
+      return 1;
+    }
+  }
+};
+const uint64_t Node_offsets[3] = {offsetof(Node, left), offsetof(Node, right), 0};
+
+Node *node_new(const int d)
+{
+  Node *result = get_gc<Node>(Node_offsets);
+  if (d > 0)
+  {
+    result->left = node_new(d - 1);
+    result->right = node_new(d - 1);
+  }
+  else
+  {
+    result->left = result->right = nullptr;
+  }
+  return result;
+}
+
+// using LS = PointerListStyle;
+// using LS = CompressedListStyle;
+using LS = CheriCompressedListStyle;
+using Iter = PointersLinkedListIterator<LS>;
+
+int main(int argc, char *argv[])
+{
+  int min_depth = 4;
+  int max_depth = std::max(min_depth + 2, (argc == 2 ? atoi(argv[1]) : 10));
+  int stretch_depth = max_depth + 1;
+  Pointers<2, LS> ptrs;
+
+  {
+    ptrs.values[0] = reinterpret_cast<GCObject *>(node_new(stretch_depth));
+    std::cout << "stretch tree of depth " << stretch_depth << "\t "
+              << "check: " << reinterpret_cast<Node *>(ptrs.values[0])->check() << std::endl;
+    walk<Iter>(&ptrs);
+  }
+
+  ptrs.values[0] = reinterpret_cast<GCObject *>(node_new(max_depth));
+
+  for (int d = min_depth; d <= max_depth; d += 2)
+  {
+    int iterations = 1 << (max_depth - d + min_depth), c = 0;
+    for (int i = 1; i <= iterations; ++i)
+    {
+      ptrs.values[1] = reinterpret_cast<GCObject *>(node_new(d));
+      c += reinterpret_cast<Node *>(ptrs.values[0])->check();
+    }
+    std::cout << iterations << "\t trees of depth " << d << "\t "
+              << "check: " << c << std::endl;
+
+    walk<Iter>(&ptrs);
+    sweep();
+  }
+
+  std::cout << "long lived tree of depth " << max_depth << "\t "
+            << "check: " << ((reinterpret_cast<Node *>(ptrs.values[0]))->check()) << "\n";
+
+  walk<Iter>(&ptrs);
+  sweep();
+  return 0;
+}

--- a/binary_trees.cpp
+++ b/binary_trees.cpp
@@ -3,6 +3,10 @@
 #include <iostream>
 #include <stdlib.h>
 
+#include "compressed.hpp"
+#include "cheri.h"
+#include "pointers.hpp"
+
 struct Node
 {
   GCObject gc;

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,8 @@
+status = ["buildbot/cheri-build-script"]
+
+timeout_sec = 600 # 10 minutes
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true
+
+cut_body_after = ""

--- a/cheri.hpp
+++ b/cheri.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+
+#if __has_feature(capabilities)
+#include "gc.hpp"
+#include <cheri/cheric.h>
+
+// On the stack inked list compression with cheri intrinsics.
+struct CheriCompressedListStyle
+{
+  static inline const uint32_t end = 0;
+
+  static const uint32_t transform(const void *ptr)
+  {
+    return static_cast<uint32_t>(cheri_getoffset(ptr));
+  }
+
+  static const void *get(uint32_t offset)
+  {
+    return cheri_setoffset(cheri_getstack(), offset);
+  }
+
+  static bool invalid(uint32_t offset)
+  {
+    return offset == 0;
+  }
+};
+
+template <> struct PointerSelector<CheriCompressedListStyle>
+{
+  using ptr_type = uint32_t;
+};
+
+// Stack Iterator that gives all the pointers it could find on the stack.
+struct CheriStackIterator
+{
+  void **location;
+
+  // Check if the pointer is pointing on the stack.
+  // Done by checking it aginst the bottom stack pointr's bounds.
+  bool is_stack(void *ptr)
+  {
+    return cheri_is_address_inbounds(bottom, cheri_getaddress(ptr));
+  }
+
+  // Check if the pointer is executable. 
+  // Done by using the permition bits.
+  bool is_exec(void *ptr)
+  {
+    return ((cheri_getperm(ptr) & 0b10) >> 1);
+  }
+
+  CheriStackIterator()
+  {
+    location = reinterpret_cast<void **>(bottom);
+  }
+
+  CheriStackIterator(void *start)
+  {
+    location = reinterpret_cast<void **>(start);
+  }
+
+  CheriStackIterator &operator++()
+  {
+    location -= 1;
+
+    // Skip all the things that arn't pointers.
+    // Also skip all the pointers we don't care about.
+    while (!cheri_gettag(*location) and (is_stack(*location) or is_exec(*location)))
+    {
+      location -= 1;
+      TRACE("Looking for pointers: %p\n", location);
+    }
+    TRACE("Found pointer: %p\n", location);
+    return *this;
+  }
+
+  bool operator!=(CheriStackIterator iter) const
+  {
+    return location != iter.location;
+  }
+  GCObject *operator*() const
+  {
+    return reinterpret_cast<GCObject *>(*location);
+  }
+
+  CheriStackIterator &begin()
+  {
+    return *this;
+  }
+
+  CheriStackIterator end()
+  {
+    return std::move(CheriStackIterator());
+  }
+};
+#endif
+

--- a/cheri.hpp
+++ b/cheri.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
 
-#include <machine/cherireg.h>
 #if __has_feature(capabilities)
 #include "gc.hpp"
+#include <machine/cherireg.h>
 #include <cheri/cheric.h>
 
-#include "../examples/include/common.h"
-// On the stack inked list compression with cheri intrinsics.
+// On the stack inked list compression with CHERI intrinsics.
 struct CheriCompressedListStyle
 {
   static inline const uint32_t end = 0;
@@ -40,33 +39,39 @@ struct CheriStackIterator
   void **location;
 
   // Check if the pointer is executable. 
-  // Done by using the permition bits.
+  // Done by using the permission bits.
+  // In practice this checks if the pointer has specific permissions 
+  // as this directly differentiates pointers on the heap and ones on the stack.
   bool is_exec(void *ptr)
   {
     TRACE("%p %d\n", ptr, (cheri_getperm(ptr) != 0x6817d));
-    //inspect_pointer(*location);
     return ((cheri_getperm(ptr) != 0x6817d) );
 
   }
   
-  // Skip all the things that arn't pointers.
-  // Also skip all the pointers we don't care about.  
+  // find the next valid GC pointer by iterating the stack and checking 
+  // the meta information for each 16 bytes.  
   void find_next() {
     TRACE("%lu\n", cheri_getaddress(bottom) - cheri_getaddress(location));
+    // If the value doesn't have a tag it can be ignored
+    // If the value doesn't have a flag it can be ignored
+    // If the value doesn't have the correct permission it can be ignored.
     while(!cheri_gettag(*location) or !cheri_getflags(*location) or is_exec(*location))  
     {
       if(location >= bottom) {
         location = (void**)bottom;
         return;
       }
-      //TRACE("Looking for pointers: %p %p\n", location, *location);
+#ifdef VERBOSE
+      TRACE("Looking for pointers: %p %p\n", location, *location);
+#endif
       location += 1;
     }
     TRACE("t: %d f: %d e: %d \n", cheri_gettag(*location), cheri_getflags(*location), !is_exec(*location));
     TRACE("Found pointer: %p\n", *location);
   }
 
-  
+  // The iteration starts from the current stack pointer. 
   CheriStackIterator(void *start)
   {
     location = reinterpret_cast<void **>(cheri_getstack());

--- a/compressed.hpp
+++ b/compressed.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "gc.hpp"
+
+struct CompressedListStyle
+{
+  static inline const uint32_t end = 0;
+
+  static uint32_t transform(const void *ptr)
+  {
+    return static_cast<uint32_t>(reinterpret_cast<uint8_t *>(bottom) -
+                                 reinterpret_cast<const uint8_t *>(ptr));
+  }
+
+  static void *get(uint32_t distance)
+  {
+    return reinterpret_cast<uint8_t *>(bottom) - distance;
+  }
+
+  static bool invalid(uint32_t distance)
+  {
+    return distance == 0;
+  }
+};
+
+template <> struct PointerSelector<CompressedListStyle>
+{
+  using ptr_type = uint32_t;
+};
+
+static_assert(std::is_standard_layout_v<Pointers<8, CompressedListStyle>>);

--- a/gc.hpp
+++ b/gc.hpp
@@ -105,10 +105,20 @@ template <typename PointerIterator> void walk(void *start)
   };
 }
 
+#if __has_feature(capabilities)
+  #include<cheri/cheric.h>
+#endif
+
 // gc allocate and put on the linked list
-template <typename Obj> Obj *get_gc(const uint64_t *_offset)
+template <typename Obj = GCObject> Obj *get_gc(const uint64_t *_offset)
 {
   GCObject *result = reinterpret_cast<GCObject *>(malloc(sizeof(Obj)));
+  TRACE("allocated: %p\n", result);
+
+#if __has_feature(capabilities)
+  result = cheri_setflags(result, 1);
+#endif
+
   result->next = start;
   start = result;
   result->type = _offset;

--- a/gc.hpp
+++ b/gc.hpp
@@ -1,0 +1,316 @@
+#include <cstddef>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+#include <utility>
+
+#if defined NDEBUG
+#define TRACE(format, ...)
+#else
+#define TRACE(format, ...)                                                                         \
+  printf("%s::%s(%d) " format, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#endif
+
+struct GCObject
+{
+  GCObject *next;
+  uint8_t mark;
+  const uint64_t *type;
+};
+static_assert(std::is_standard_layout_v<GCObject>);
+
+static thread_local GCObject *start = nullptr;
+static thread_local uint8_t timeWalked = 0;
+static inline void *bottom = 0;
+
+struct CompressedListStyle
+{
+  static inline const uint32_t end = 0;
+
+  static uint32_t transform(const void *ptr)
+  {
+    return static_cast<uint32_t>(reinterpret_cast<uint8_t *>(bottom) -
+                                 reinterpret_cast<const uint8_t *>(ptr));
+  }
+
+  static void *get(uint32_t distance)
+  {
+    return reinterpret_cast<uint8_t *>(bottom) - distance;
+  }
+
+  static bool invalid(uint32_t distance)
+  {
+    return distance == 0;
+  }
+};
+
+template <typename ListStyle> struct PointerSelector
+{
+  using ptr_type = const void *;
+};
+
+template <> struct PointerSelector<CompressedListStyle>
+{
+  using ptr_type = uint32_t;
+};
+
+template <uint32_t count, typename ListStyle> struct Pointers
+{
+  uint32_t size = count;
+  uint32_t depth;
+  using ptr_type = typename PointerSelector<ListStyle>::ptr_type;
+  ptr_type previous;
+  GCObject *values[count] = {nullptr};
+
+  Pointers() : depth(0), previous(ListStyle::end) {}
+
+  Pointers(const void *previous)
+  {
+    this->previous = ListStyle::transform(previous);
+    depth = reinterpret_cast<const Pointers *>(ListStyle::get(this->previous))->depth + 1;
+  }
+};
+static_assert(std::is_standard_layout_v<Pointers<8, CompressedListStyle>>);
+
+struct PointerListStyle
+{
+  static inline const Pointers<0, PointerListStyle> *end = nullptr;
+
+  static const Pointers<0, PointerListStyle> *transform(const void *ptr)
+  {
+    return reinterpret_cast<const Pointers<0, PointerListStyle> *>(ptr);
+  }
+
+  static const void *get(const void *ptr)
+  {
+    return ptr;
+  }
+
+  static bool invalid(const void *ptr)
+  {
+    return ptr == nullptr;
+  }
+};
+
+template <> struct PointerSelector<PointerListStyle>
+{
+  using ptr_type = const Pointers<0, PointerListStyle> *;
+};
+
+#if __has_feature(capabilities)
+#include <cheri/cheric.h>
+struct CheriCompressedListStyle
+{
+  static inline const uint32_t end = 0;
+
+  static const uint32_t transform(const void *ptr)
+  {
+    return static_cast<uint32_t>(cheri_getoffset(ptr));
+  }
+
+  static const void *get(uint32_t offset)
+  {
+    return cheri_setoffset(cheri_getstack(), offset);
+  }
+
+  static bool invalid(uint32_t offset)
+  {
+    return offset == 0;
+  }
+};
+
+template <> struct PointerSelector<CheriCompressedListStyle>
+{
+  using ptr_type = uint32_t;
+};
+
+#endif
+
+void sweep()
+{
+  GCObject **current = &start;
+  while (true)
+  {
+    TRACE("LookingAt: %p, Type: %p, Mark: %x \n", current, (*current)->type, (*current)->mark);
+    if ((*current)->mark != timeWalked)
+    {
+      TRACE("Freeing: %p\n", current);
+      auto next = (*current)->next;
+      free(*current);
+      *current = next;
+    }
+    else
+    {
+      current = &(*current)->next;
+    }
+    if (*current == nullptr)
+    {
+      break;
+    }
+  }
+}
+
+void mark(uint8_t d, GCObject *object)
+{
+  if (object == nullptr)
+  {
+    return;
+  }
+  else if (object->mark == timeWalked)
+  {
+    return;
+  }
+  if (d > 0)
+  {
+    TRACE("pointer[%d]: Value: %p Type: %p\n", d, object, object->type);
+  }
+  object->mark = timeWalked;
+  for (size_t index = 0; object->type[index] != 0; index++)
+  {
+    mark(d + 1,
+         *reinterpret_cast<GCObject **>(reinterpret_cast<uint8_t *>(object) + object->type[index]));
+  }
+}
+
+template <typename ListStyle> struct PointersLinkedListIterator
+{
+  const Pointers<0, ListStyle> *curr;
+  uint32_t index;
+
+  PointersLinkedListIterator()
+  {
+    curr = nullptr;
+  }
+
+  PointersLinkedListIterator(void *start)
+  {
+    index = 0;
+    curr = reinterpret_cast<Pointers<0, ListStyle> *>(start);
+
+    /*
+    TRACE("Size: %u Depth: %u\n", curr->size, curr->depth);
+    for (uint32_t size = 0; size < curr->size; size++) {
+
+      TRACE("pointer[%d]: Value: %p\n", size, curr->values[size]);
+    }
+    */
+  }
+
+  PointersLinkedListIterator &operator++()
+  {
+    index += 1;
+    if (index == curr->size)
+    {
+      TRACE("check: %u %p\n", curr->previous, ListStyle::get(curr->previous));
+      if (ListStyle::invalid(curr->previous))
+      {
+        curr = nullptr;
+      }
+      else
+      {
+        index = 0;
+        curr = reinterpret_cast<const Pointers<0, ListStyle> *>(ListStyle::get(curr->previous));
+        TRACE("Size: %u Depth: %u\n", curr->size, curr->depth);
+      }
+    }
+    return *this;
+  }
+
+  bool operator!=(PointersLinkedListIterator iter) const
+  {
+    return curr != iter.curr;
+  }
+  GCObject *operator*() const
+  {
+    return curr->values[index];
+  }
+
+  PointersLinkedListIterator &begin()
+  {
+    return *this;
+  }
+
+  PointersLinkedListIterator end()
+  {
+    return std::move(PointersLinkedListIterator());
+  }
+};
+
+#if __has_feature(capabilities)
+struct CheriStackIterator
+{
+  void **location;
+
+  bool is_stack(void *ptr)
+  {
+    return cheri_is_address_inbounds(bottom, cheri_getaddress(ptr));
+  }
+
+  bool is_exec(void *ptr)
+  {
+    return ((cheri_getperm(ptr) & 0b10) >> 1);
+  }
+
+  CheriStackIterator()
+  {
+    location = reinterpret_cast<void **>(bottom);
+  }
+
+  CheriStackIterator(void *start)
+  {
+    location = reinterpret_cast<void **>(start);
+  }
+
+  CheriStackIterator &operator++()
+  {
+    location -= 1;
+    while (!cheri_gettag(*location) and (is_stack(*location) or is_exec(*location)))
+    {
+      location -= 1;
+      TRACE("Looking for pointers: %p\n", location);
+    }
+    TRACE("Found pointer: %p\n", location);
+    return *this;
+  }
+
+  bool operator!=(CheriStackIterator iter) const
+  {
+    return location != iter.location;
+  }
+  GCObject *operator*() const
+  {
+    return reinterpret_cast<GCObject *>(*location);
+  }
+
+  CheriStackIterator &begin()
+  {
+    return *this;
+  }
+
+  CheriStackIterator end()
+  {
+    return std::move(CheriStackIterator());
+  }
+};
+#endif
+
+template <typename PointerIterator> void walk(void *start)
+{
+  timeWalked += 1;
+
+  for (GCObject *lookedAt : PointerIterator(start))
+  {
+    TRACE("pointer[%d]: Value: %p\n", 0, lookedAt);
+    mark(0, lookedAt);
+  };
+}
+
+template <typename Obj> Obj *get_gc(const uint64_t *_offset)
+{
+  GCObject *result = reinterpret_cast<GCObject *>(malloc(sizeof(Obj)));
+  result->next = start;
+  start = result;
+  result->type = _offset;
+  return reinterpret_cast<Obj *>(result);
+}

--- a/gc.hpp
+++ b/gc.hpp
@@ -5,6 +5,8 @@
 #include <type_traits>
 #include <utility>
 
+#pragma once
+
 #if defined NDEBUG
 #define TRACE(format, ...)
 #else
@@ -24,35 +26,9 @@ static thread_local GCObject *start = nullptr;
 static thread_local uint8_t timeWalked = 0;
 static inline void *bottom = 0;
 
-struct CompressedListStyle
-{
-  static inline const uint32_t end = 0;
-
-  static uint32_t transform(const void *ptr)
-  {
-    return static_cast<uint32_t>(reinterpret_cast<uint8_t *>(bottom) -
-                                 reinterpret_cast<const uint8_t *>(ptr));
-  }
-
-  static void *get(uint32_t distance)
-  {
-    return reinterpret_cast<uint8_t *>(bottom) - distance;
-  }
-
-  static bool invalid(uint32_t distance)
-  {
-    return distance == 0;
-  }
-};
-
 template <typename ListStyle> struct PointerSelector
 {
   using ptr_type = const void *;
-};
-
-template <> struct PointerSelector<CompressedListStyle>
-{
-  using ptr_type = uint32_t;
 };
 
 template <uint32_t count, typename ListStyle> struct Pointers
@@ -71,61 +47,6 @@ template <uint32_t count, typename ListStyle> struct Pointers
     depth = reinterpret_cast<const Pointers *>(ListStyle::get(this->previous))->depth + 1;
   }
 };
-static_assert(std::is_standard_layout_v<Pointers<8, CompressedListStyle>>);
-
-struct PointerListStyle
-{
-  static inline const Pointers<0, PointerListStyle> *end = nullptr;
-
-  static const Pointers<0, PointerListStyle> *transform(const void *ptr)
-  {
-    return reinterpret_cast<const Pointers<0, PointerListStyle> *>(ptr);
-  }
-
-  static const void *get(const void *ptr)
-  {
-    return ptr;
-  }
-
-  static bool invalid(const void *ptr)
-  {
-    return ptr == nullptr;
-  }
-};
-
-template <> struct PointerSelector<PointerListStyle>
-{
-  using ptr_type = const Pointers<0, PointerListStyle> *;
-};
-
-#if __has_feature(capabilities)
-#include <cheri/cheric.h>
-struct CheriCompressedListStyle
-{
-  static inline const uint32_t end = 0;
-
-  static const uint32_t transform(const void *ptr)
-  {
-    return static_cast<uint32_t>(cheri_getoffset(ptr));
-  }
-
-  static const void *get(uint32_t offset)
-  {
-    return cheri_setoffset(cheri_getstack(), offset);
-  }
-
-  static bool invalid(uint32_t offset)
-  {
-    return offset == 0;
-  }
-};
-
-template <> struct PointerSelector<CheriCompressedListStyle>
-{
-  using ptr_type = uint32_t;
-};
-
-#endif
 
 void sweep()
 {
@@ -173,128 +94,6 @@ void mark(uint8_t d, GCObject *object)
   }
 }
 
-template <typename ListStyle> struct PointersLinkedListIterator
-{
-  const Pointers<0, ListStyle> *curr;
-  uint32_t index;
-
-  PointersLinkedListIterator()
-  {
-    curr = nullptr;
-  }
-
-  PointersLinkedListIterator(void *start)
-  {
-    index = 0;
-    curr = reinterpret_cast<Pointers<0, ListStyle> *>(start);
-
-    /*
-    TRACE("Size: %u Depth: %u\n", curr->size, curr->depth);
-    for (uint32_t size = 0; size < curr->size; size++) {
-
-      TRACE("pointer[%d]: Value: %p\n", size, curr->values[size]);
-    }
-    */
-  }
-
-  PointersLinkedListIterator &operator++()
-  {
-    index += 1;
-    if (index == curr->size)
-    {
-      TRACE("check: %u %p\n", curr->previous, ListStyle::get(curr->previous));
-      if (ListStyle::invalid(curr->previous))
-      {
-        curr = nullptr;
-      }
-      else
-      {
-        index = 0;
-        curr = reinterpret_cast<const Pointers<0, ListStyle> *>(ListStyle::get(curr->previous));
-        TRACE("Size: %u Depth: %u\n", curr->size, curr->depth);
-      }
-    }
-    return *this;
-  }
-
-  bool operator!=(PointersLinkedListIterator iter) const
-  {
-    return curr != iter.curr;
-  }
-  GCObject *operator*() const
-  {
-    return curr->values[index];
-  }
-
-  PointersLinkedListIterator &begin()
-  {
-    return *this;
-  }
-
-  PointersLinkedListIterator end()
-  {
-    return std::move(PointersLinkedListIterator());
-  }
-};
-
-#if __has_feature(capabilities)
-struct CheriStackIterator
-{
-  void **location;
-
-  bool is_stack(void *ptr)
-  {
-    return cheri_is_address_inbounds(bottom, cheri_getaddress(ptr));
-  }
-
-  bool is_exec(void *ptr)
-  {
-    return ((cheri_getperm(ptr) & 0b10) >> 1);
-  }
-
-  CheriStackIterator()
-  {
-    location = reinterpret_cast<void **>(bottom);
-  }
-
-  CheriStackIterator(void *start)
-  {
-    location = reinterpret_cast<void **>(start);
-  }
-
-  CheriStackIterator &operator++()
-  {
-    location -= 1;
-    while (!cheri_gettag(*location) and (is_stack(*location) or is_exec(*location)))
-    {
-      location -= 1;
-      TRACE("Looking for pointers: %p\n", location);
-    }
-    TRACE("Found pointer: %p\n", location);
-    return *this;
-  }
-
-  bool operator!=(CheriStackIterator iter) const
-  {
-    return location != iter.location;
-  }
-  GCObject *operator*() const
-  {
-    return reinterpret_cast<GCObject *>(*location);
-  }
-
-  CheriStackIterator &begin()
-  {
-    return *this;
-  }
-
-  CheriStackIterator end()
-  {
-    return std::move(CheriStackIterator());
-  }
-};
-#endif
-
 template <typename PointerIterator> void walk(void *start)
 {
   timeWalked += 1;
@@ -306,6 +105,7 @@ template <typename PointerIterator> void walk(void *start)
   };
 }
 
+// gc allocate and put on the linked list
 template <typename Obj> Obj *get_gc(const uint64_t *_offset)
 {
   GCObject *result = reinterpret_cast<GCObject *>(malloc(sizeof(Obj)));

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,91 @@
+#include <cstddef>
+#include <optional>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <vector>
+
+#include "gc.hpp"
+
+using LS = CompressedListStyle;
+
+struct String
+{
+  GCObject gc;
+  uint32_t size;
+  uint8_t value[256];
+};
+const uint64_t String_offsets[1] = {0};
+
+struct Car
+{
+  GCObject gc;
+  uint32_t speed;
+  uint32_t color;
+  String *brand;
+};
+const uint64_t Car_offsets[2] = {offsetof(Car, brand), 0};
+
+static_assert(std::is_standard_layout_v<Car>);
+static_assert(std::is_standard_layout_v<String>);
+
+String *string_new(char *str)
+{
+  String *result = get_gc<String>(String_offsets);
+  strcpy(reinterpret_cast<char *>(result->value), str);
+  return result;
+}
+
+Car *car_new(uint32_t speed, uint32_t color)
+{
+  Car *result = get_gc<Car>(Car_offsets);
+  result->color = color;
+  result->speed = speed;
+  return result;
+}
+
+Car *car_combine(const void *prev, Car *car1, Car *car2)
+{
+  Pointers<1, LS> ptrs(prev);
+  ptrs.values[0] = (GCObject *)car_new(car1->speed, car2->color);
+  reinterpret_cast<Car *>(ptrs.values[0])->brand = string_new("Combined");
+
+  return reinterpret_cast<Car *>(ptrs.values[0]);
+}
+
+void car_print(const void *prev, Car *self)
+{
+  Pointers<1, LS> ptrs(prev);
+
+  printf("Car(speed: %u, color: %u", self->speed, self->color);
+  if (self->brand != nullptr)
+  {
+    printf(", brand: \"%s\")\n", self->brand->value);
+    self->brand = nullptr;
+  }
+  else
+  {
+    printf(")\n");
+  }
+
+  walk<PointersLinkedListIterator<LS>>(&ptrs);
+  sweep();
+}
+
+int main()
+{
+  Pointers<2, LS> ptrs;
+  CompressedListStyle::bottom = __builtin_frame_address(0);
+
+  ptrs.values[0] = (GCObject *)car_new(120, 0);
+  ptrs.values[1] = (GCObject *)car_new(80, 1);
+  reinterpret_cast<Car *>(ptrs.values[1])->brand = string_new("MyOwn");
+
+  ptrs.values[0] = (GCObject *)car_combine(&ptrs, reinterpret_cast<Car *>(ptrs.values[0]),
+                                           reinterpret_cast<Car *>(ptrs.values[1]));
+
+  car_print(&ptrs, reinterpret_cast<Car *>(ptrs.values[1]));
+  car_print(&ptrs, reinterpret_cast<Car *>(ptrs.values[0]));
+
+  printf("FINISH\n");
+}

--- a/main.cpp
+++ b/main.cpp
@@ -6,8 +6,14 @@
 #include <vector>
 
 #include "gc.hpp"
+#include "compressed.hpp"
+#include "pointers.hpp"
+#include "cheri.hpp"
+
 
 using LS = CompressedListStyle;
+//using Iter = PointersLinkedListIterator<LS>;
+using Iter = CheriStackIterator;
 
 struct String
 {
@@ -68,14 +74,14 @@ void car_print(const void *prev, Car *self)
     printf(")\n");
   }
 
-  walk<PointersLinkedListIterator<LS>>(&ptrs);
+  walk<Iter>(&ptrs);
   sweep();
 }
 
 int main()
 {
   Pointers<2, LS> ptrs;
-  CompressedListStyle::bottom = __builtin_frame_address(0);
+  bottom = __builtin_frame_address(0);
 
   ptrs.values[0] = (GCObject *)car_new(120, 0);
   ptrs.values[1] = (GCObject *)car_new(80, 1);

--- a/main.cpp
+++ b/main.cpp
@@ -12,8 +12,8 @@
 
 
 using LS = CompressedListStyle;
-//using Iter = PointersLinkedListIterator<LS>;
-using Iter = CheriStackIterator;
+using Iter = PointersLinkedListIterator<LS>;
+//using Iter = CheriStackIterator;
 
 struct String
 {

--- a/pointers.hpp
+++ b/pointers.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "gc.hpp"
+
+struct PointerListStyle
+{
+  static inline const Pointers<0, PointerListStyle> *end = nullptr;
+
+  static const Pointers<0, PointerListStyle> *transform(const void *ptr)
+  {
+    return reinterpret_cast<const Pointers<0, PointerListStyle> *>(ptr);
+  }
+
+  static const void *get(const void *ptr)
+  {
+    return ptr;
+  }
+
+  static bool invalid(const void *ptr)
+  {
+    return ptr == nullptr;
+  }
+};
+
+template <> struct PointerSelector<PointerListStyle>
+{
+  using ptr_type = const Pointers<0, PointerListStyle> *;
+};
+
+static_assert(std::is_standard_layout_v<Pointers<8, PointerListStyle>>);
+
+
+// Iterate all the pointers on the special Pointers structure on the stack.
+// The Pointers structure makes a linked list so it can be easily followed.
+template <typename ListStyle> struct PointersLinkedListIterator
+{
+  const Pointers<0, ListStyle> *curr;
+  uint32_t index;
+
+  PointersLinkedListIterator()
+  {
+    curr = nullptr;
+  }
+
+  PointersLinkedListIterator(void *start)
+  {
+    index = 0;
+    curr = reinterpret_cast<Pointers<0, ListStyle> *>(start);
+
+    /*
+    TRACE("Size: %u Depth: %u\n", curr->size, curr->depth);
+    for (uint32_t size = 0; size < curr->size; size++) {
+
+      TRACE("pointer[%d]: Value: %p\n", size, curr->values[size]);
+    }
+    */
+  }
+
+  PointersLinkedListIterator &operator++()
+  {
+    index += 1;
+    if (index == curr->size)
+    {
+      TRACE("check: %u %p\n", curr->previous, ListStyle::get(curr->previous));
+      if (ListStyle::invalid(curr->previous))
+      {
+        curr = nullptr;
+      }
+      else
+      {
+        index = 0;
+        curr = reinterpret_cast<const Pointers<0, ListStyle> *>(ListStyle::get(curr->previous));
+        TRACE("Size: %u Depth: %u\n", curr->size, curr->depth);
+      }
+    }
+    return *this;
+  }
+
+  bool operator!=(PointersLinkedListIterator iter) const
+  {
+    return curr != iter.curr;
+  }
+  GCObject *operator*() const
+  {
+    return curr->values[index];
+  }
+
+  PointersLinkedListIterator &begin()
+  {
+    return *this;
+  }
+
+  PointersLinkedListIterator end()
+  {
+    return std::move(PointersLinkedListIterator());
+  }
+};
+

--- a/pointers.hpp
+++ b/pointers.hpp
@@ -46,14 +46,6 @@ template <typename ListStyle> struct PointersLinkedListIterator
   {
     index = 0;
     curr = reinterpret_cast<Pointers<0, ListStyle> *>(start);
-
-    /*
-    TRACE("Size: %u Depth: %u\n", curr->size, curr->depth);
-    for (uint32_t size = 0; size < curr->size; size++) {
-
-      TRACE("pointer[%d]: Value: %p\n", size, curr->values[size]);
-    }
-    */
   }
 
   PointersLinkedListIterator &operator++()

--- a/stack.cpp
+++ b/stack.cpp
@@ -1,0 +1,83 @@
+#include "gc.hpp"
+#include "compressed.hpp"
+#include "cheri.hpp"
+#include "pointers.hpp"
+
+struct A {
+  GCObject gc;
+  int a;
+};
+
+struct C {
+  GCObject gc;
+  uint32_t c[16];
+};
+
+const uint64_t offsets[1] = {0};
+
+using LS = PointerListStyle;
+//using LS = CompressedListStyle;
+//using LS = CheriCompressedListStyle;
+using Iter = CheriStackIterator;
+//using Iter = PointersLinkedListIterator<LS>;
+
+void function_a(void* prev, uint32_t d);
+void function_b(void* prev, uint32_t d);
+void function_c(void* prev, uint32_t d);
+
+void function_a(void* prev, uint32_t d) {
+  Pointers<3, LS> ptrs(prev);
+  ptrs.values[0] = (GCObject*)get_gc<A>(offsets);
+  ptrs.values[1] = (GCObject*)get_gc<C>(offsets);
+  ptrs.values[2] = (GCObject*)get_gc<C>(offsets);
+  
+  uint32_t s[16] = {};
+  for(uint32_t i = 0; i < 16; i++) {
+    s[i] = reinterpret_cast<C*>(ptrs.values[1])->c[i] + 
+           reinterpret_cast<C*>(ptrs.values[2])->c[i];
+  }
+
+  for(uint32_t i = 0; i < 16; i++) {
+    reinterpret_cast<A*>(ptrs.values[0])->a += s[i];
+  }
+
+  function_b(&ptrs, d);
+
+}
+
+void function_b(void* prev, uint32_t d) {
+  Pointers<3, LS> ptrs(prev);
+  ptrs.values[0] = (GCObject*)get_gc<A>(offsets);
+  ptrs.values[1] = (GCObject*)get_gc<A>(offsets);
+  ptrs.values[2] = (GCObject*)get_gc<A>(offsets);
+ 
+  function_c(&ptrs, d);
+}
+
+void function_c(void* prev, uint32_t d) {
+  Pointers<1, LS> ptrs(prev);
+  ptrs.values[0] = (GCObject*)get_gc<A>(offsets);
+  
+  char path[32] = "00000000";
+  path[d % 8] = '1';
+  printf("Test: %s\n", path);
+
+  if(d > 300) {
+    walk<Iter>(&ptrs);
+    sweep();
+  }else{
+    function_a(&ptrs, d + 1);
+  }
+}
+
+int main() {
+  bottom = __builtin_frame_address(0);
+  Pointers<1, LS> root;
+  
+  for(uint32_t i = 0; i < 1; i++) {
+    function_a(&root, 0);
+  }
+
+  walk<Iter>(&root);
+  sweep();
+}


### PR DESCRIPTION
A very simple GC. 

Uses a non-moving mark: https://github.com/capablevms/cheri-example-gc/blob/27c6a2be651acd05c16e908a8e58174e71b36863/gc.hpp#L97 
and sweep
https://github.com/capablevms/cheri-example-gc/blob/27c6a2be651acd05c16e908a8e58174e71b36863/gc.hpp#L51
 approach. 

The original reason was to check how different stack scanning approaches work on cheri. 
The first approach was to have a special stack, for the "VM" and scan that. 
This stack can represent the referances for it's linked list in 3 distinct types:
 - Pointers https://github.com/capablevms/cheri-example-gc/blob/27c6a2be651acd05c16e908a8e58174e71b36863/pointers.hpp#L5-L23
 - Normal pointer compression https://github.com/capablevms/cheri-example-gc/blob/27c6a2be651acd05c16e908a8e58174e71b36863/compressed.hpp#L5-L24
 - Cheri compressed pointers https://github.com/capablevms/cheri-example-gc/blob/27c6a2be651acd05c16e908a8e58174e71b36863/cheri.hpp#L9-L27 
There also is an iterator that just scans the whole stack using cheri intrinsics.
https://github.com/capablevms/cheri-example-gc/blob/27c6a2be651acd05c16e908a8e58174e71b36863/cheri.hpp#L35

The main motivation behind this is to see which features would be more beneficial to implement inside of the lua vm, instead of replacing a whole buch of code and having no way to go back. Also, it is an interesting way to show how CHERI features can be used the implement a piece of code when having CHERI as a primary target.